### PR TITLE
Fix vertical spacing in README

### DIFF
--- a/projects/project2/project_text_classification/README.md
+++ b/projects/project2/project_text_classification/README.md
@@ -28,10 +28,13 @@ Below is a solution pipeline with an evaluation step:
 
 Load the training tweets given in `pos_train.txt`, `neg_train.txt` (or a suitable subset depending on RAM requirements), and construct a a vocabulary list of words appearing at least 5 times. This is done running the following commands. Note that the provided `cooc.py` script can take a few minutes to run, and displays the number of tweets processed.
 
-```build_vocab.sh
+```bash
+build_vocab.sh
 cut_vocab.sh
 python3 pickle_vocab.py
-python3 cooc.py```
+python3 cooc.py
+```
+
 
 Now given the co-occurrence matrix and the vocabulary, it is not hard to train GloVe word embeddings, that is to compute an embedding vector for wach word in the vocabulary. We suggest to implement SGD updates to train the matrix factorization, as in
 
@@ -40,6 +43,7 @@ Now given the co-occurrence matrix and the vocabulary, it is not hard to train G
 Once you tested your system on the small set of 10% of all tweets, we suggest you run on the full datasets `pos_train_full.txt`, `neg_train_full.txt`
 
 ### Building a Text Classifier:
+
 1. Construct Features for the Training Texts: Load the training tweets and the built GloVe word embeddings. Using the word embeddings, construct a feature representation of each training tweet (by averaging the word vectors over all words of the tweet).
 
 2. Train a Linear Classifier: Train a linear classifier (e.g. logistic regression or SVM) on your constructed features, using the scikit learn library, or your own code from the earlier labs. Recall that the labels indicate if a tweet used to contain a :) or :( smiley.


### PR DESCRIPTION
The end of the readme for text-classification project was hard to read due to some text being recognized as code by github. I added spacing between existing code block and text to fix this.