### PR TITLE
Modified batch_iter function

### DIFF
--- a/labs/ex02/template/helpers.py
+++ b/labs/ex02/template/helpers.py
@@ -57,21 +57,55 @@ def batch_iter(y, tx, batch_size, num_batches=1, shuffle=True):
     Takes as input two iterables (here the output desired values 'y' and the input data 'tx')
     Outputs an iterator which gives mini-batches of `batch_size` matching elements from `y` and `tx`.
     Data can be randomly shuffled to avoid ordering in the original data messing with the randomness of the minibatches.
+
+    Example:
+
+     Number of batches = 9
+
+     Batch size = 7                              Remainder = 3
+     v     v                                         v v
+    |-------|-------|-------|-------|-------|-------|---|
+        0       7       14      21      28      35   max batches = 6
+
+    If shuffle is False, the returned batches are the ones started from the indexes:
+    0, 7, 14, 21, 28, 35, 0, 7, 14
+
+    If shuffle is True, the returned batches start in:
+    7, 28, 14, 35, 14, 0, 21, 28, 7
+
+    To prevent the remainder datapoints from ever being taken into account, each of the shuffled indexes is added a random amount
+    8, 28, 16, 38, 14, 0, 22, 28, 9
+
+    This way batches might overlap, but the returned batches are slightly more representative.
+
+    Disclaimer: To keep this function simple, individual datapoints are not shuffled. For a more random result consider using a batch_size of 1.
+
     Example of use :
     for minibatch_y, minibatch_tx in batch_iter(y, tx, 32):
         <DO-SOMETHING>
     """
-    data_size = len(y)
+    data_size = len(y)  # NUmber of data points.
+    batch_size = min(data_size, batch_size)  # Limit the possible size of the batch.
+    max_batches = int(
+        data_size / batch_size
+    )  # The maximum amount of non-overlapping batches that can be extracted from the data.
+    remainder = (
+        data_size - max_batches * batch_size
+    )  # Points that would be excluded if no overlap is allowed.
 
     if shuffle:
-        shuffle_indices = np.random.permutation(np.arange(data_size))
-        shuffled_y = y[shuffle_indices]
-        shuffled_tx = tx[shuffle_indices]
+        # Generate an array of indexes indicating the start of each batch
+        idxs = np.random.randint(max_batches, size=num_batches) * batch_size
+        if remainder != 0:
+            # Add an random offset to the start of each batch to eventually consider the remainder points
+            idxs += np.random.randint(remainder + 1, size=num_batches)
     else:
-        shuffled_y = y
-        shuffled_tx = tx
-    for batch_num in range(num_batches):
-        start_index = batch_num * batch_size
-        end_index = min((batch_num + 1) * batch_size, data_size)
-        if start_index != end_index:
-            yield shuffled_y[start_index:end_index], shuffled_tx[start_index:end_index]
+        # If no shuffle is done, the array of indexes is circular.
+        idxs = np.array([i % max_batches for i in range(num_batches)]) * batch_size
+
+    for start in idxs:
+        start_index = start  # The first data point of the batch
+        end_index = (
+            start_index + batch_size
+        )  # The first data point of the following batch
+        yield y[start_index:end_index], tx[start_index:end_index]


### PR DESCRIPTION
For a while a had the same problem as [Jakhongir's question in the forum](https://edstem.org/eu/courses/797/discussion/53083): The implementation of `batch_iter` forces you to reshuffle if your choice of `batch_size` and `num_batches` is not happy (e.g. too large batches and/or too little batches and/or more batches than which fit inside the dataset). 

In order to comply with the test from Project 1 (which has one single data point but requires 2 iterations) and use the `batch_iter` function you would need to do some inefficient nested `for`, shuffling the (single) data twice.

I propose this different approach (shuffling indexes instead of the data-points). It is compliant with the project tests and way more efficient than the previous one (given some reasonable circumstances). Furthermore, it allows to have as many iterations as desired, regardless of the dataset size. 

![image](https://github.com/epfml/ML_course/assets/54960111/111fabcc-e152-4cc0-841a-fa3709d6da51)
 
The implementation has certain caveats regarding the randomness inside the batch, but the obvious workaround is using `batch_size = 1`, which should still be (slightly) more efficient. 

Regards, thank you and keep up the awesome work! 