### PR TITLE
fix: array shape in task B's docstrings are wrong

### DIFF
--- a/labs/ex01/solution/taskB.ipynb
+++ b/labs/ex01/solution/taskB.ipynb
@@ -83,8 +83,8 @@
     "    A naive solution for finding pairvise distances between poins in P and Q\n",
     "\n",
     "    Args:\n",
-    "        P: numpy array of shape=(p, 2)\n",
-    "        Q: numpy array of shape=(q, 2)\n",
+    "        P: numpy array of shape=(p, n)\n",
+    "        Q: numpy array of shape=(q, n)\n",
     "    Returns:\n",
     "        D: numpy array of shape=(p, q)\n",
     "\n",
@@ -247,8 +247,8 @@
     "    An optimized solution using matching indices\n",
     "\n",
     "    Args:\n",
-    "        P: numpy array of shape=(p, 2)\n",
-    "        Q: numpy array of shape=(q, 2)\n",
+    "        P: numpy array of shape=(p, n)\n",
+    "        Q: numpy array of shape=(q, n)\n",
     "    Returns:\n",
     "        D: numpy array of shape=(p, q)\n",
     "\n",
@@ -284,8 +284,8 @@
     "    An optimized solution using matching indices\n",
     "\n",
     "    Args:\n",
-    "        P: numpy array of shape=(p, 2)\n",
-    "        Q: numpy array of shape=(q, 2)\n",
+    "        P: numpy array of shape=(p, n)\n",
+    "        Q: numpy array of shape=(q, n)\n",
     "    Returns:\n",
     "        D: numpy array of shape=(p, q)\n",
     "\n",
@@ -324,8 +324,8 @@
     "    A solution using scipy\n",
     "\n",
     "    Args:\n",
-    "        P: numpy array of shape=(p, 2)\n",
-    "        Q: numpy array of shape=(q, 2)\n",
+    "        P: numpy array of shape=(p, n)\n",
+    "        Q: numpy array of shape=(q, n)\n",
     "\n",
     "    Returns:\n",
     "        D: numpy array of shape=(p, q)\n",
@@ -354,8 +354,8 @@
     "    A solution using tensor broadcasting\n",
     "\n",
     "    Args:\n",
-    "        P: numpy array of shape=(p, 2)\n",
-    "        Q: numpy array of shape=(q, 2)\n",
+    "        P: numpy array of shape=(p, n)\n",
+    "        Q: numpy array of shape=(q, n)\n",
     "\n",
     "    Returns:\n",
     "        D: numpy array of shape=(p, q)\n",
@@ -472,10 +472,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/labs/ex01/solution/taskB.ipynb
+++ b/labs/ex01/solution/taskB.ipynb
@@ -472,24 +472,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 1
 }

--- a/labs/ex01/solution/taskB.ipynb
+++ b/labs/ex01/solution/taskB.ipynb
@@ -473,6 +473,7 @@
  ],
  "metadata": {
   "language_info": {
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/labs/ex01/template/taskB.ipynb
+++ b/labs/ex01/template/taskB.ipynb
@@ -20,6 +20,7 @@
   },
   {
    "cell_type": "markdown",
+   "execution_count": null,
    "metadata": {},
    "source": [
     "Data Generation\n",
@@ -41,6 +42,7 @@
   },
   {
    "cell_type": "markdown",
+   "execution_count": null,
    "metadata": {},
    "source": [
     "Solution\n",
@@ -85,6 +87,7 @@
   },
   {
    "cell_type": "markdown",
+   "execution_count": null,
    "metadata": {},
    "source": [
     "### Use matching indices\n",
@@ -151,6 +154,7 @@
   },
   {
    "cell_type": "markdown",
+   "execution_count": null,
    "metadata": {},
    "source": [
     "### Use a library\n",
@@ -186,6 +190,7 @@
   },
   {
    "cell_type": "markdown",
+   "execution_count": null,
    "metadata": {},
    "source": [
     "### Numpy Magic"
@@ -216,6 +221,7 @@
   },
   {
    "cell_type": "markdown",
+   "execution_count": null,
    "metadata": {},
    "source": [
     "# Compare methods"
@@ -266,24 +272,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
 }

--- a/labs/ex01/template/taskB.ipynb
+++ b/labs/ex01/template/taskB.ipynb
@@ -20,7 +20,6 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
    "source": [
     "Data Generation\n",
@@ -42,7 +41,6 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
    "source": [
     "Solution\n",
@@ -60,8 +58,8 @@
     "    A naive solution for finding pairvise distances between poins in P and Q\n",
     "\n",
     "    Args:\n",
-    "        P: numpy array of shape=(p, 2)\n",
-    "        Q: numpy array of shape=(q, 2)\n",
+    "        P: numpy array of shape=(p, n)\n",
+    "        Q: numpy array of shape=(q, n)\n",
     "    Returns:\n",
     "        D: numpy array of shape=(p, q)\n",
     "\n",
@@ -87,7 +85,6 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
    "source": [
     "### Use matching indices\n",
@@ -127,8 +124,8 @@
     "    An optimized solution using matching indices\n",
     "\n",
     "    Args:\n",
-    "        P: numpy array of shape=(p, 2)\n",
-    "        Q: numpy array of shape=(q, 2)\n",
+    "        P: numpy array of shape=(p, n)\n",
+    "        Q: numpy array of shape=(q, n)\n",
     "    Returns:\n",
     "        D: numpy array of shape=(p, q)\n",
     "\n",
@@ -154,7 +151,6 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
    "source": [
     "### Use a library\n",
@@ -176,8 +172,8 @@
     "    A solution using scipy\n",
     "\n",
     "    Args:\n",
-    "        P: numpy array of shape=(p, 2)\n",
-    "        Q: numpy array of shape=(q, 2)\n",
+    "        P: numpy array of shape=(p, n)\n",
+    "        Q: numpy array of shape=(q, n)\n",
     "\n",
     "    Returns:\n",
     "        D: numpy array of shape=(p, q)\n",
@@ -190,7 +186,6 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
    "source": [
     "### Numpy Magic"
@@ -207,8 +202,8 @@
     "    A solution using tensor broadcasting\n",
     "\n",
     "    Args:\n",
-    "        P: numpy array of shape=(p, 2)\n",
-    "        Q: numpy array of shape=(q, 2)\n",
+    "        P: numpy array of shape=(p, n)\n",
+    "        Q: numpy array of shape=(q, n)\n",
     "\n",
     "    Returns:\n",
     "        D: numpy array of shape=(p, q)\n",
@@ -221,7 +216,6 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
    "source": [
     "# Compare methods"
@@ -272,10 +266,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/labs/ex01/template/taskB.ipynb
+++ b/labs/ex01/template/taskB.ipynb
@@ -273,7 +273,9 @@
  ],
  "metadata": {
   "language_info": {
+   "name": "python"
   }
  },
  "nbformat": 4,
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Given that the task uses `P_big` and `Q_big` of shapes `[x, 80]` at the very end to compare speed, the docstrings should reflect that the functions should generalise over any `n` and not just `n=2`.